### PR TITLE
correct status codes for auth header issues

### DIFF
--- a/middleware/echo/iamruntimemiddleware/authentication.go
+++ b/middleware/echo/iamruntimemiddleware/authentication.go
@@ -16,19 +16,19 @@ import (
 func setAuthenticationContext(c echo.Context) error {
 	bearer, err := internal.GetBearerToken(c.Request())
 	if err != nil {
-		return echo.ErrBadRequest.WithInternal(fmt.Errorf("%w: %s", iamruntime.AuthError, err))
+		return echo.ErrUnauthorized.WithInternal(fmt.Errorf("%w: %s", iamruntime.AuthError, err))
 	}
 
 	ctx := c.Request().Context()
 
 	token, _, err := jwt.NewParser().ParseUnverified(bearer, jwt.MapClaims{})
 	if err != nil {
-		return echo.ErrBadRequest.WithInternal(fmt.Errorf("%w: failed to parse jwt: %w", iamruntime.AuthError, err))
+		return echo.ErrUnauthorized.WithInternal(fmt.Errorf("%w: failed to parse jwt: %w", iamruntime.AuthError, err))
 	}
 
 	subject, err := token.Claims.GetSubject()
 	if err != nil {
-		return echo.ErrBadRequest.WithInternal(fmt.Errorf("%w: failed to get subject from jwt: %w", iamruntime.AuthError, err))
+		return echo.ErrUnauthorized.WithInternal(fmt.Errorf("%w: failed to get subject from jwt: %w", iamruntime.AuthError, err))
 	}
 
 	ctx = iamruntime.SetContextToken(ctx, token)
@@ -46,12 +46,10 @@ func setAuthenticationContext(c echo.Context) error {
 func ValidateCredential(c echo.Context, in *authentication.ValidateCredentialRequest, opts ...grpc.CallOption) error {
 	if err := iamruntime.ContextValidateCredential(c.Request().Context(), in, opts...); err != nil {
 		switch {
-		case errors.Is(err, iamruntime.ErrTokenNotFound):
-			return echo.ErrBadRequest.WithInternal(err)
+		case errors.Is(err, iamruntime.ErrTokenNotFound), errors.Is(err, iamruntime.ErrInvalidCredentials):
+			return echo.ErrUnauthorized.WithInternal(err)
 		case errors.Is(err, iamruntime.ErrRuntimeNotFound), errors.Is(err, iamruntime.ErrCredentialValidationRequestFailed):
 			return echo.ErrInternalServerError.WithInternal(err)
-		case errors.Is(err, iamruntime.ErrInvalidCredentials):
-			return echo.ErrUnauthorized.WithInternal(err)
 		default:
 			return echo.ErrInternalServerError.WithInternal(fmt.Errorf("unknown error: %w", err))
 		}


### PR DESCRIPTION
The correct status code to return when an invalid authorization header has been provided is a 401 Unauthorized.

https://www.rfc-editor.org/rfc/rfc9110#name-www-authenticate