### PR TITLE
add ContextCheckAccessTo for simplified access checks

### DIFF
--- a/iamruntime/authorization.go
+++ b/iamruntime/authorization.go
@@ -38,6 +38,25 @@ func ContextCheckAccess(ctx context.Context, actions []*authorization.AccessRequ
 	return nil
 }
 
+// ContextCheckAccessTo builds a check access request and executes it on the runtime in the provided context.
+// Arguments must be pairs of Resource ID and Role Actions.
+func ContextCheckAccessTo(ctx context.Context, resourceIDActionPairs ...string) error {
+	if len(resourceIDActionPairs)%2 != 0 {
+		return fmt.Errorf("%w: invalid argument count", ErrResourceIDActionPairsInvalid)
+	}
+
+	var checkActions []*authorization.AccessRequestAction
+
+	for i := 0; i < len(resourceIDActionPairs); i += 2 {
+		checkActions = append(checkActions, &authorization.AccessRequestAction{
+			ResourceId: resourceIDActionPairs[i],
+			Action:     resourceIDActionPairs[i+1],
+		})
+	}
+
+	return ContextCheckAccess(ctx, checkActions)
+}
+
 // ContextCreateRelationships executes a create relationship request on the runtime in the context.
 // Context must have a runtime value.
 // The runtime must implement the iam-runtime's AuthorizationClient.

--- a/iamruntime/errors.go
+++ b/iamruntime/errors.go
@@ -27,6 +27,9 @@ var (
 	// AccessError is the root error for all access related errors.
 	AccessError = fmt.Errorf("%w: access", Error) //nolint:revive,stylecheck // not returned directly, but used as a root error.
 
+	// ErrResourceIDActionPairsInvalid is returned when ContextCheckAccessTo has an invalid number of arguments.
+	ErrResourceIDActionPairsInvalid = fmt.Errorf("%w: ContextCheckAccessTo invalid Resource ID, Action argument pairs", AccessError)
+
 	// ErrAccessCheckFailed is the error returned when an access request failed to execute.
 	ErrAccessCheckFailed = fmt.Errorf("%w: failed to check access", AccessError)
 


### PR DESCRIPTION
Having to define the AccessRequestAction for each CheckAccess request is not a great user experience for this middleware.

To solve this, ContextCheckAccessTo has been added which will construct the AccessRequestActions from argument pairs, greatly simplifying access requests.