### PR TITLE
add grpc health methods to runtime.

### DIFF
--- a/iamruntime/errors.go
+++ b/iamruntime/errors.go
@@ -50,4 +50,7 @@ var (
 
 	// ErrAccessTokenInvalid is the error returned when an access token returned is not valid.
 	ErrAccessTokenInvalid = fmt.Errorf("%w: invalid access token", IdentityError)
+
+	// ErrNotReady is returned when an individual health check is not ready.
+	ErrNotReady = fmt.Errorf("%w: runtime not ready", Error)
 )

--- a/iamruntime/health.go
+++ b/iamruntime/health.go
@@ -1,0 +1,91 @@
+package iamruntime
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/codes"
+	health "google.golang.org/grpc/health/grpc_health_v1"
+	"google.golang.org/grpc/status"
+)
+
+// HealthyRuntime extends [Runtime] adding grpc Health Client.
+type HealthyRuntime interface {
+	Runtime
+
+	// HealthCheck calls the health service Check call.
+	HealthCheck(ctx context.Context, in *health.HealthCheckRequest, opts ...grpc.CallOption) (*health.HealthCheckResponse, error)
+
+	// HealthWatch calls the health service Watch call.
+	HealthWatch(ctx context.Context, in *health.HealthCheckRequest, opts ...grpc.CallOption) (grpc.ServerStreamingClient[health.HealthCheckResponse], error)
+
+	// WaitHealthy calls the health service check waiting for a SERVING status.
+	// If the backend returns an unimplemented status code, no error is returned.
+	WaitHealthy(ctx context.Context, in *health.HealthCheckRequest, opts ...grpc.CallOption) error
+
+	// WaitHealthyWithTimeout calls WaitHealthy with a timeout.
+	// [ErrHealthCheckTimedout] is returned if a healthy response is not received within the provided timeout.
+	WaitHealthyWithTimeout(ctx context.Context, timeout time.Duration, in *health.HealthCheckRequest, opts ...grpc.CallOption) error
+}
+
+// HealthCheck calls the health service Check call.
+func (r *runtime) HealthCheck(ctx context.Context, in *health.HealthCheckRequest, opts ...grpc.CallOption) (*health.HealthCheckResponse, error) {
+	return r.HealthClient.Check(ctx, in, opts...)
+}
+
+// HealthWatch calls the health service Watch call.
+func (r *runtime) HealthWatch(ctx context.Context, in *health.HealthCheckRequest, opts ...grpc.CallOption) (grpc.ServerStreamingClient[health.HealthCheckResponse], error) {
+	return r.HealthClient.Watch(ctx, in, opts...)
+}
+
+// healthy returns true when a successful serving response is received from the runtime.
+func (r *runtime) healthy(ctx context.Context, in *health.HealthCheckRequest, opts ...grpc.CallOption) error {
+	resp, err := r.HealthCheck(ctx, in, opts...)
+	if err != nil {
+		if status.Code(err) == codes.Unimplemented {
+			return nil
+		}
+
+		return fmt.Errorf("%w: health check error: %w", ErrNotReady, err)
+	}
+
+	if resp.Status == health.HealthCheckResponse_SERVING {
+		return nil
+	}
+
+	return fmt.Errorf("%w: %s", ErrNotReady, resp.Status)
+}
+
+// WaitHealthy calls the health service check waiting for a SERVING status.
+// If the backend returns an unimplemented status code, no error is returned.
+func (r *runtime) WaitHealthy(ctx context.Context, in *health.HealthCheckRequest, opts ...grpc.CallOption) error {
+	ticker := time.NewTicker(r.healthyInterval)
+	defer ticker.Stop()
+
+	err := r.healthy(ctx, in, opts...)
+	if err == nil {
+		return nil
+	}
+
+	for {
+		select {
+		case <-ctx.Done():
+			return fmt.Errorf("%w: %w", err, ctx.Err())
+		case <-ticker.C:
+			err = r.healthy(ctx, in, opts...)
+			if err == nil {
+				return nil
+			}
+		}
+	}
+}
+
+// WaitHealthyWithTimeout calls WaitHealthy with a timeout.
+func (r *runtime) WaitHealthyWithTimeout(ctx context.Context, timeout time.Duration, in *health.HealthCheckRequest, opts ...grpc.CallOption) error {
+	ctx, cancel := context.WithTimeout(ctx, timeout)
+	defer cancel()
+
+	return r.WaitHealthy(ctx, in, opts...)
+}

--- a/iamruntime/health_test.go
+++ b/iamruntime/health_test.go
@@ -1,0 +1,367 @@
+package iamruntime
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/health/grpc_health_v1"
+	"google.golang.org/grpc/status"
+)
+
+var _ grpc_health_v1.HealthClient = (*mockHealthClient)(nil)
+
+type mockHealthClient struct {
+	mu sync.Mutex
+
+	checkCalled bool
+	watchCalled bool
+
+	checkReturnResponse *grpc_health_v1.HealthCheckResponse
+	checkReturnError    error
+}
+
+func (c *mockHealthClient) setCheckReturn(response *grpc_health_v1.HealthCheckResponse, err error) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	c.checkReturnResponse = response
+	c.checkReturnError = err
+}
+
+// Check implements a mock HealthClient Check.
+func (c *mockHealthClient) Check(_ context.Context, _ *grpc_health_v1.HealthCheckRequest, _ ...grpc.CallOption) (*grpc_health_v1.HealthCheckResponse, error) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	c.checkCalled = true
+
+	return c.checkReturnResponse, c.checkReturnError
+}
+
+// Watch implements a mock HealthClient Watch.
+func (c *mockHealthClient) Watch(_ context.Context, _ *grpc_health_v1.HealthCheckRequest, _ ...grpc.CallOption) (grpc.ServerStreamingClient[grpc_health_v1.HealthCheckResponse], error) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	c.watchCalled = true
+
+	return nil, status.Error(codes.Unimplemented, "method Watch not implemented")
+}
+
+func TestHealthy(t *testing.T) {
+	t.Parallel()
+
+	testCases := []struct {
+		name          string
+		checkResponse *grpc_health_v1.HealthCheckResponse
+		checkError    error
+		expectError   error
+	}{
+		{
+			"healthy",
+			&grpc_health_v1.HealthCheckResponse{
+				Status: grpc_health_v1.HealthCheckResponse_SERVING,
+			},
+			nil,
+			nil,
+		},
+		{
+			"unhealthy: not serving",
+			&grpc_health_v1.HealthCheckResponse{
+				Status: grpc_health_v1.HealthCheckResponse_NOT_SERVING,
+			},
+			nil,
+			ErrNotReady,
+		},
+		{
+			"unhealthy: error",
+			nil,
+			grpc.ErrServerStopped,
+			ErrNotReady,
+		},
+		{
+			"healthy: unimplemented",
+			nil,
+			status.Error(codes.Unimplemented, "method Check not implemented"),
+			nil,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			mockHealth := &mockHealthClient{
+				checkReturnResponse: tc.checkResponse,
+				checkReturnError:    tc.checkError,
+			}
+
+			runtime := &runtime{
+				HealthClient: mockHealth,
+			}
+
+			ctx := context.Background()
+
+			err := runtime.healthy(ctx, &grpc_health_v1.HealthCheckRequest{})
+
+			if tc.expectError != nil {
+				require.Error(t, err, "expected error to be returned")
+				assert.ErrorIs(t, err, tc.expectError, "unexpected error returned")
+			} else {
+				assert.NoError(t, err, "expected no error to be returned")
+			}
+
+			assert.True(t, mockHealth.checkCalled, "expected Check to be called")
+			assert.False(t, mockHealth.watchCalled, "expected Watch to not be called")
+		})
+	}
+}
+
+func TestWaitHealthy(t *testing.T) {
+	t.Parallel()
+
+	testCases := []struct {
+		name          string
+		startupDelay  time.Duration
+		checkResponse *grpc_health_v1.HealthCheckResponse
+		checkError    error
+		expectErrors  []error
+	}{
+		{
+			"healthy",
+			0,
+			&grpc_health_v1.HealthCheckResponse{
+				Status: grpc_health_v1.HealthCheckResponse_SERVING,
+			},
+			nil,
+			nil,
+		},
+		{
+			"healthy delayed",
+			20 * time.Millisecond,
+			&grpc_health_v1.HealthCheckResponse{
+				Status: grpc_health_v1.HealthCheckResponse_SERVING,
+			},
+			nil,
+			nil,
+		},
+		{
+			"unhealthy: not serving: context canceled",
+			0,
+			&grpc_health_v1.HealthCheckResponse{
+				Status: grpc_health_v1.HealthCheckResponse_NOT_SERVING,
+			},
+			nil,
+			[]error{
+				context.DeadlineExceeded,
+				ErrNotReady,
+			},
+		},
+		{
+			"unhealthy: error: context canceled",
+			20 * time.Millisecond,
+			nil,
+			grpc.ErrServerStopped,
+			[]error{
+				context.DeadlineExceeded,
+				ErrNotReady,
+				grpc.ErrServerStopped,
+			},
+		},
+		{
+			"healthy: unimplemented",
+			20 * time.Millisecond,
+			nil,
+			status.Error(codes.Unimplemented, "method Check not implemented"),
+			nil,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			mockHealth := &mockHealthClient{}
+
+			runtime := &runtime{
+				HealthClient:    mockHealth,
+				healthyInterval: time.Millisecond,
+			}
+
+			ctx, cancel := context.WithTimeout(context.Background(), 100*time.Millisecond)
+			defer cancel()
+
+			if tc.startupDelay != 0 {
+				mockHealth.checkReturnError = io.ErrUnexpectedEOF
+
+				defer time.AfterFunc(tc.startupDelay, func() {
+					mockHealth.setCheckReturn(tc.checkResponse, tc.checkError)
+				}).Stop()
+			} else {
+				mockHealth.checkReturnResponse = tc.checkResponse
+				mockHealth.checkReturnError = tc.checkError
+			}
+
+			err := runtime.WaitHealthy(ctx, &grpc_health_v1.HealthCheckRequest{})
+
+			if len(tc.expectErrors) != 0 {
+				require.Error(t, err, "expected error to be returned")
+
+				for _, expectError := range tc.expectErrors {
+					assert.ErrorIs(t, err, expectError, "unexpected error returned")
+				}
+			} else {
+				assert.NoError(t, err, "expected no error to be returned")
+			}
+
+			assert.True(t, mockHealth.checkCalled, "expected Check to be called")
+			assert.False(t, mockHealth.watchCalled, "expected Watch to not be called")
+		})
+	}
+}
+
+func TestWaitHealthyWithTimeout(t *testing.T) {
+	t.Parallel()
+
+	testCases := []struct {
+		name          string
+		startupDelay  time.Duration
+		checkResponse *grpc_health_v1.HealthCheckResponse
+		checkError    error
+		expectErrors  []error
+	}{
+		{
+			"healthy",
+			0,
+			&grpc_health_v1.HealthCheckResponse{
+				Status: grpc_health_v1.HealthCheckResponse_SERVING,
+			},
+			nil,
+			nil,
+		},
+		{
+			"healthy delayed",
+			20 * time.Millisecond,
+			&grpc_health_v1.HealthCheckResponse{
+				Status: grpc_health_v1.HealthCheckResponse_SERVING,
+			},
+			nil,
+			nil,
+		},
+		{
+			"unhealthy: not serving: timed out",
+			0,
+			&grpc_health_v1.HealthCheckResponse{
+				Status: grpc_health_v1.HealthCheckResponse_NOT_SERVING,
+			},
+			nil,
+			[]error{
+				context.DeadlineExceeded,
+				ErrNotReady,
+			},
+		},
+		{
+			"unhealthy: error: timed out",
+			20 * time.Millisecond,
+			nil,
+			grpc.ErrServerStopped,
+			[]error{
+				context.DeadlineExceeded,
+				ErrNotReady,
+				grpc.ErrServerStopped,
+			},
+		},
+		{
+			"healthy: unimplemented",
+			20 * time.Millisecond,
+			nil,
+			status.Error(codes.Unimplemented, "method Check not implemented"),
+			nil,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			mockHealth := &mockHealthClient{}
+
+			runtime := &runtime{
+				HealthClient:    mockHealth,
+				healthyInterval: time.Millisecond,
+			}
+
+			// ctx, cancel := context.WithTimeout(context.Background(), 200*time.Millisecond)
+			// defer cancel()
+
+			ctx := context.Background()
+
+			if tc.startupDelay != 0 {
+				mockHealth.checkReturnError = io.ErrUnexpectedEOF
+
+				defer time.AfterFunc(tc.startupDelay, func() {
+					mockHealth.setCheckReturn(tc.checkResponse, tc.checkError)
+				}).Stop()
+			} else {
+				mockHealth.checkReturnResponse = tc.checkResponse
+				mockHealth.checkReturnError = tc.checkError
+			}
+
+			err := runtime.WaitHealthyWithTimeout(ctx, 100*time.Millisecond, &grpc_health_v1.HealthCheckRequest{})
+
+			if len(tc.expectErrors) != 0 {
+				require.Error(t, err, "expected error to be returned")
+
+				for _, expectError := range tc.expectErrors {
+					assert.ErrorIs(t, err, expectError, "unexpected error returned")
+				}
+			} else {
+				assert.NoError(t, err, "expected no error to be returned")
+			}
+
+			assert.True(t, mockHealth.checkCalled, "expected Check to be called")
+			assert.False(t, mockHealth.watchCalled, "expected Watch to not be called")
+		})
+	}
+}
+
+func ExampleHealthyRuntime_HealthCheck() {
+	runtime, _ := NewClient("unix:///tmp/runtime.sock")
+
+	health, err := runtime.HealthCheck(context.TODO(), &grpc_health_v1.HealthCheckRequest{})
+	if err != nil {
+		panic("health check failed: " + err.Error())
+	}
+
+	fmt.Println("Health status:", health.Status)
+}
+
+func ExampleHealthyRuntime_WaitHealthy() {
+	runtime, _ := NewClient("unix:///tmp/runtime.sock")
+
+	err := runtime.WaitHealthy(context.TODO(), &grpc_health_v1.HealthCheckRequest{})
+	if err != nil {
+		panic("health check failed: " + err.Error())
+	}
+
+	// use healthy runtime
+}
+
+func ExampleHealthyRuntime_WaitHealthyWithTimeout() {
+	runtime, _ := NewClient("unix:///tmp/runtime.sock")
+
+	err := runtime.WaitHealthyWithTimeout(context.TODO(), time.Minute, &grpc_health_v1.HealthCheckRequest{})
+	if err != nil {
+		panic("health check failed: " + err.Error())
+	}
+
+	// use healthy runtime
+}

--- a/iamruntime/runtime.go
+++ b/iamruntime/runtime.go
@@ -1,13 +1,30 @@
 package iamruntime
 
 import (
+	"context"
+	"os"
+	"time"
+
 	"github.com/metal-toolbox/iam-runtime/pkg/iam/runtime/authentication"
 	"github.com/metal-toolbox/iam-runtime/pkg/iam/runtime/authorization"
 	"github.com/metal-toolbox/iam-runtime/pkg/iam/runtime/identity"
 	"go.opentelemetry.io/contrib/instrumentation/google.golang.org/grpc/otelgrpc"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/credentials/insecure"
+	health "google.golang.org/grpc/health/grpc_health_v1"
 )
+
+const defaultNewClientWaitTimeout = 10 * time.Second
+
+func newClientWaitTimeout() time.Duration {
+	if sTimeout := os.Getenv("IAMRUNTIME_NEW_CLIENT_WAIT_TIMEOUT"); sTimeout != "" {
+		if timeout, err := time.ParseDuration(sTimeout); err == nil {
+			return timeout
+		}
+	}
+
+	return defaultNewClientWaitTimeout
+}
 
 // Runtime implements all iam-runtime clients.
 type Runtime interface {
@@ -20,13 +37,15 @@ type runtime struct {
 	authorization.AuthorizationClient
 	authentication.AuthenticationClient
 	identity.IdentityClient
+
+	health.HealthClient
+	healthyInterval time.Duration
 }
 
-// NewClient creates a new iam-runtime which implements all clients.
+// NewClientWithoutWait creates a new iam-runtime which implements all clients.
 //
-// GRPC Insecure transport credentials are configured by default.
-// This may be overwritten by providing an alternative TransportCredentials dial option.
-func NewClient(target string, dialOpts ...grpc.DialOption) (Runtime, error) {
+// See [NewClient] for more details.
+func NewClientWithoutWait(target string, dialOpts ...grpc.DialOption) (HealthyRuntime, error) {
 	dialOpts = append([]grpc.DialOption{
 		grpc.WithTransportCredentials(insecure.NewCredentials()),
 		grpc.WithStatsHandler(otelgrpc.NewClientHandler()),
@@ -41,5 +60,36 @@ func NewClient(target string, dialOpts ...grpc.DialOption) (Runtime, error) {
 		AuthorizationClient:  authorization.NewAuthorizationClient(conn),
 		AuthenticationClient: authentication.NewAuthenticationClient(conn),
 		IdentityClient:       identity.NewIdentityClient(conn),
+		HealthClient:         health.NewHealthClient(conn),
+		healthyInterval:      time.Second,
 	}, nil
+}
+
+// NewClient creates a new iam-runtime which implements all clients.
+//
+// NewClient blocks for up to 10 seconds waiting for a healthy runtime server response.
+// If no healthy response is found within this period, an error is returned.
+// Use [runtime.WaitHealthyWithTimeout] after creating a new client to use a configurable timeout.
+//
+// Use [NewClientWithoutWait] to initialize a new runtime without waiting for the service to report healthy.
+//
+// Alter the new client wait timeout with setting `IAMRUNTIME_NEW_CLIENT_WAIT_TIMEOUT` environment variable.
+// A value of 0 or less will disable waiting.
+//
+// GRPC Insecure transport credentials are configured by default.
+// This may be overwritten by providing an alternative TransportCredentials dial option.
+func NewClient(target string, dialOpts ...grpc.DialOption) (HealthyRuntime, error) {
+	runtime, err := NewClientWithoutWait(target, dialOpts...)
+	if err != nil {
+		return nil, err
+	}
+
+	if timeout := newClientWaitTimeout(); timeout > 0 {
+		err = runtime.WaitHealthyWithTimeout(context.Background(), timeout, &health.HealthCheckRequest{})
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	return runtime, nil
 }

--- a/iamruntime/runtime_test.go
+++ b/iamruntime/runtime_test.go
@@ -5,10 +5,26 @@ import (
 	"fmt"
 
 	"github.com/metal-toolbox/iam-runtime/pkg/iam/runtime/authentication"
+	"google.golang.org/grpc/health/grpc_health_v1"
 )
 
 func ExampleNewClient() {
 	runtime, _ := NewClient("unix:///tmp/runtime.sock")
+
+	resp, _ := runtime.ValidateCredential(context.TODO(), &authentication.ValidateCredentialRequest{
+		Credential: "some credential",
+	})
+
+	fmt.Println("Result:", resp.Result.String())
+	fmt.Println("Subject:", resp.Subject.SubjectId)
+}
+
+func ExampleNewClientWithoutWait() {
+	runtime, _ := NewClientWithoutWait("unix:///tmp/runtime.sock")
+
+	if err := runtime.WaitHealthy(context.Background(), &grpc_health_v1.HealthCheckRequest{}); err != nil {
+		panic(err)
+	}
 
 	resp, _ := runtime.ValidateCredential(context.TODO(), &authentication.ValidateCredentialRequest{
 		Credential: "some credential",


### PR DESCRIPTION
This adds the standard grpc_health_v1 service to the iamruntime package. This provides support for checking health on the runtime ensuring the runtime is healthy before use.

BEHAVIOR CHANGE:

With the introduction of the health check service, NewClient has been updated to block, waiting for the service to report healthy. NewClient will block for up to 10 seconds before reporting that the runtime is not healthy.
If the runtime reports the health service is unimplemented, it is assumed the runtime is ready and unblocks the request.

This behavior change ensures clients are making requests against a healthy runtime. To disable this new behavior `NewClient` must be updated to `NewClientWithoutWait`. Alternatively setting the environment variable `IAMRUNTIME_NEW_CLIENT_WAIT_TIMEOUT` to 0 will disable this new behavior.